### PR TITLE
fix version incrementing

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,25 @@ func exitWithError(message string) {
 	os.Exit(1)
 }
 
+func bump(old *semver.Version, part string) *semver.Version {
+	// We don't want to mutate the input, but there's no Clone or Copy method on a semver.Version,
+	// so we make a new one by parsing the string version of the old one.
+	// We ignore any errors because we know it's valid semver.
+	new, _ := semver.New(old.String())
+	switch part {
+	case "major":
+		new.Major++
+		new.Minor = 0
+		new.Patch = 0
+	case "minor":
+		new.Minor++
+		new.Patch = 0
+	case "patch":
+		new.Patch++
+	}
+	return new
+}
+
 func main() {
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %s: [options] version\n\n", os.Args[0])
@@ -79,12 +98,8 @@ func main() {
 
 	newVersion := flag.Args()[0]
 	switch newVersion {
-	case "patch":
-		version.Patch++
-	case "minor":
-		version.Minor++
-	case "major":
-		version.Major++
+	case "patch", "minor", "major":
+		version = bump(version, newVersion)
 	default:
 		if version, err = semver.New(newVersion); err != nil {
 			log.Fatalf("failed to parse %s as semver: %s", newVersion, err.Error())

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/blang/semver.v1"
+	"testing"
+)
+
+var bumpTests = []struct {
+	Old    string
+	New    string
+	Change string
+}{
+	{Old: "1.0.0", New: "2.0.0", Change: "major"},
+	{Old: "1.1.0", New: "2.0.0", Change: "major"},
+	{Old: "1.1.1", New: "2.0.0", Change: "major"},
+	{Old: "1.0.0", New: "1.1.0", Change: "minor"},
+	{Old: "1.0.1", New: "1.1.0", Change: "minor"},
+	{Old: "1.1.1", New: "1.1.2", Change: "patch"},
+}
+
+func TestBump(t *testing.T) {
+	for _, test := range bumpTests {
+		v, err := semver.New(test.Old)
+		assert.Nil(t, err)
+		assert.Equal(t, test.New, bump(v, test.Change).String())
+	}
+}


### PR DESCRIPTION
prior to this change, if you tried to do a major version bump on 1.1.5,
the result would be 2.1.5 instead of the expected 2.0.0
