### PR TITLE
Ignore git version and configuration differences.

### DIFF
--- a/git.go
+++ b/git.go
@@ -7,7 +7,7 @@ import (
 )
 
 func isRepoClean() (bool, error) {
-	cmd := exec.Command("git", "status", "-s")
+	cmd := exec.Command("git", "status", "--porcelain")
 	result := &bytes.Buffer{}
 	cmd.Stdout = result
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
From [the `git status` docs](https://git-scm.com/docs/git-status#git-status---porcelainltversiongt):
```
--porcelain
Give the output in an easy-to-parse format for scripts.
This is similar to the short output, but will remain stable across Git versions
and regardless of user configuration.
```

For example, `isRepoClean()` currently returns `false` even when the repo is clean when using
the `status.branch` config option, because it assumes that the output will always be empty when the repo is clean.

```
$ git config status.branch true
$ git status
## master...origin/master
$ gitsem minor
2017/05/25 18:16:48 repo isn't clean
$ git config status.branch false
$ git status # prints nothing
$ gitsem minor # works
```