### PR TITLE
Allow for annotated tags and dry run

### DIFF
--- a/git.go
+++ b/git.go
@@ -34,6 +34,12 @@ func commit(message string) error {
 	return exec.Command("git", "commit", "-m", message).Run()
 }
 
-func tag(version string) error {
-	return exec.Command("git", "tag", version).Run()
+func tag(version string, annotate bool) error {
+	var cmd *exec.Cmd
+	if annotate {
+		cmd = exec.Command("git", "tag", "-a", version, "-m", version)
+	} else {
+		cmd = exec.Command("git", "tag", version)
+	}
+	return cmd.Run()
 }

--- a/main.go
+++ b/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"gopkg.in/blang/semver.v1"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"gopkg.in/blang/semver.v1"
 )
 
 func commitMessage(message, version string) string {
@@ -66,6 +67,7 @@ func main() {
 	message := flag.String("m", "%s", "commit message for version commit")
 	help := flag.Bool("h", false, "print usage and exit")
 	shouldTag := flag.Bool("tag", true, "whether or not to make a tag at the version commit")
+	annotate := flag.Bool("annotate", true, "whether or not to make the tag an annotated tag")
 	flag.Parse()
 
 	if *help {
@@ -118,7 +120,7 @@ func main() {
 		log.Fatal(err)
 	}
 	if *shouldTag {
-		if err := tag(versionString); err != nil {
+		if err := tag(versionString, *annotate); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ func main() {
 	shouldTag := flag.Bool("tag", true, "whether or not to make a tag at the version commit")
 	annotate := flag.Bool("annotate", true, "whether or not to make the tag an annotated tag")
 	dryrun := flag.Bool("dry-run", false, "see next version with out making commits")
+	verbose := flag.Bool("v", false, "verbose output")
 	flag.Parse()
 
 	if *help {
@@ -114,10 +115,12 @@ func main() {
 
 	if *dryrun {
 		// quit early and print result
-		fmt.Println("Dry run.")
-		fmt.Println("Your current version is:")
-		fmt.Println("v" + previousVersion.String())
-		fmt.Println("Your next version would be:")
+		if *verbose {
+			fmt.Println("Dry run.")
+			fmt.Println("Your current version is:")
+			fmt.Println("v" + previousVersion.String())
+			fmt.Println("Your next version would be:")
+		}
 		fmt.Println(versionString)
 		os.Exit(0)
 	}


### PR DESCRIPTION
Added support for tag annotation to support the [`--follow-tags` support in git](https://git-scm.com/docs/git-push#git-push---follow-tags) and git docs [recommend using annotated tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_creating_tags).

Added `dry-run` flag in case you wanted to see the next version without committing. 